### PR TITLE
fix(拉起支付弹窗)

### DIFF
--- a/web/src/views/Topup/component/PayDialog.js
+++ b/web/src/views/Topup/component/PayDialog.js
@@ -16,11 +16,17 @@ const PayDialog = ({ open, onClose, amount, uuid }) => {
   const [qrCodeUrl, setQrCodeUrl] = useState(null);
   const [success, setSuccess] = useState(false);
   const [intervalId, setIntervalId] = useState(null);
-
+  const siteInfoStorage = localStorage.getItem('siteInfo');
+  let siteInfo;
+  if (siteInfoStorage) {
+    siteInfo = JSON.parse(siteInfoStorage);
+  }
+  const useLogo = siteInfo.logo ? siteInfo.logo : defaultLogo;
   useEffect(() => {
     if (!open) {
       return;
     }
+
     setMessage('正在拉起支付中...');
     setLoading(true);
 
@@ -99,7 +105,7 @@ const PayDialog = ({ open, onClose, amount, uuid }) => {
       <DialogContent>
         <DialogContent>
           <Stack direction="column" justifyContent="center" alignItems="center" spacing={2}>
-            {loading && <img src={defaultLogo} alt="loading" height="100" />}
+            {loading && <img src={useLogo} alt="loading" height="100" />}
             {qrCodeUrl && (
               <QRCode
                 value={qrCodeUrl}


### PR DESCRIPTION
当用户设置系统logo的情况下拉起支付弹窗显示用户自己设置的logo而不是显示默认的logo-loading图


我已确认该 PR 已自测通过，相关截图如下：
![截图_SuperAI - Google Chrome_2024-6-6-11_41_35](https://github.com/MartialBE/one-api/assets/19732560/1fb71de7-e38c-4da1-9e5e-59080437b644)

