### PR TITLE
🔖 chore: Alipay QR code payment add open Alipay button

### DIFF
--- a/web/src/views/Topup/component/PayDialog.js
+++ b/web/src/views/Topup/component/PayDialog.js
@@ -72,8 +72,6 @@ const PayDialog = ({ open, onClose, amount, uuid }) => {
           setMessage('支付成功');
           setLoading(false);
           setSuccess(true);
-          //支付成功清空旧的二维码
-          setQrCodeUrl('');
           clearInterval(id);
           setIntervalId(null);
         }

--- a/web/src/views/Topup/component/PayDialog.js
+++ b/web/src/views/Topup/component/PayDialog.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { useState, useEffect } from 'react';
-import { Dialog, DialogContent, DialogTitle, IconButton, Stack, Typography } from '@mui/material';
+import { Button, Dialog, DialogContent, DialogTitle, IconButton, Stack, Typography } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { useTheme } from '@mui/material/styles';
 import { QRCode } from 'react-qrcode-logo';
@@ -26,7 +26,6 @@ const PayDialog = ({ open, onClose, amount, uuid }) => {
     if (!open) {
       return;
     }
-
     setMessage('正在拉起支付中...');
     setLoading(true);
 
@@ -73,6 +72,8 @@ const PayDialog = ({ open, onClose, amount, uuid }) => {
           setMessage('支付成功');
           setLoading(false);
           setSuccess(true);
+          //支付成功清空旧的二维码
+          setQrCodeUrl('');
           clearInterval(id);
           setIntervalId(null);
         }
@@ -80,7 +81,12 @@ const PayDialog = ({ open, onClose, amount, uuid }) => {
     }, 3000);
     setIntervalId(id);
   };
-
+  //打开支付宝
+  const handleOpenAlipay = (alipayUrl) => {
+    if (alipayUrl && alipayUrl.startsWith('https://qr.alipay.com')) {
+      window.open(alipayUrl, '_blank');
+    }
+  };
   return (
     <Dialog open={open} fullWidth maxWidth={'sm'} disableEscapeKeyDown>
       <DialogTitle sx={{ margin: '0px', fontWeight: 700, lineHeight: '1.55556', padding: '24px', fontSize: '1.125rem' }}>支付</DialogTitle>
@@ -118,6 +124,11 @@ const PayDialog = ({ open, onClose, amount, uuid }) => {
             )}
             {success && <img src={successSvg} alt="success" height="100" />}
             <Typography variant="h3">{message}</Typography>
+            {qrCodeUrl && qrCodeUrl.startsWith('https://qr.alipay.com') && !success && (
+              <Button variant="contained" color="primary" onClick={() => handleOpenAlipay(qrCodeUrl)}>
+                打开支付宝
+              </Button>
+            )}
           </Stack>
         </DialogContent>
       </DialogContent>


### PR DESCRIPTION
支付宝扫码支付弹窗增加打开支付宝按钮，手机端点击按钮可以直接拉起支付宝进行支付。

![image](https://github.com/MartialBE/one-api/assets/19732560/7d1ed8c7-c33a-4daa-bb4a-a427ba7e6fed)
