### PR TITLE
🐛fix: aliPay missing parameters

### DIFF
--- a/payment/gateway/alipay/payment.go
+++ b/payment/gateway/alipay/payment.go
@@ -86,6 +86,7 @@ func (a *Alipay) Pay(config *types.PayConfig, gatewayConfig string) (*types.PayR
 		p.Subject = sysconfig.SystemName + "-Token充值:" + p.TotalAmount
 		p.NotifyURL = config.NotifyURL
 		p.ReturnURL = config.ReturnURL
+		p.ProductCode = "FAST_INSTANT_TRADE_PAY"
 		alipayRes, err := client.TradePagePay(p)
 		if err != nil {
 			return nil, fmt.Errorf("alipay trade precreate failed: %s", err.Error())

--- a/web/src/views/Payment/type/Config.js
+++ b/web/src/views/Payment/type/Config.js
@@ -99,7 +99,7 @@ const PaymentConfig = {
           value: 'facepay'
         },
         {
-          name: '跳转支付',
+          name: '电脑网站支付',
           value: 'pagepay'
         }
       ]


### PR DESCRIPTION
修复跳转后缺少支付宝PC网站必要参数的问题

