### PR TITLE
fix: correct  prices of abab6.5-chat & abab6.5s-chat

### DIFF
--- a/prices.json
+++ b/prices.json
@@ -689,15 +689,15 @@
     "model": "abab6.5-chat",
     "type": "tokens",
     "channel_type": 27,
-    "input": 0.7143,
-    "output": 0.7143
+    "input": 2.1429,
+    "output": 2.1429
   },
   {
     "model": "abab6.5s-chat",
     "type": "tokens",
     "channel_type": 27,
-    "input": 2.1429,
-    "output": 2.1429
+    "input": 0.7143,
+    "output": 0.7143
   },
   {
     "model": "embo-01",


### PR DESCRIPTION
[//]: # "请按照以下格式关联 issue"
[//]: # "请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢"
[//]: # "项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解"
[//]: # "请在提交 PR 之前删除上面的注释"

price.json 中 minimax 的 abab6.5-chat 和 abab6.5s-chat，价格搞反了，前者价格是后者三倍，分别对于倍率应该是 abab6.5-chat ：2.1429 ，abab6.5s-chat：0.7143

见官方文档：https://platform.minimaxi.com/document/price?id=6433f32294878d408fc8293e
![CleanShot 2024-06-22 at 17 50 17](https://github.com/MartialBE/one-api/assets/33158166/d76963a8-05cd-4b5f-ae20-3c2c661b3fcd)


我已确认该 PR 已自测通过